### PR TITLE
Compatibility fix for Contao devel branch.

### DIFF
--- a/EasyThemes.php
+++ b/EasyThemes.php
@@ -119,7 +119,7 @@ class EasyThemes extends Backend
 		// - it has been disabled (what a luminary)
 		// - there is no theme at all
 		// - the user has no module activated at all
-		$arrAllThemes	= $this->getThemes();
+		$arrAllThemes	= $this->getAllThemes();
 		$arrNavArray	= $this->prepareBackendNavigationArray();
 		
 		if($this->User->et_enable != 1 || !$arrAllThemes || !$arrNavArray)
@@ -140,7 +140,7 @@ class EasyThemes extends Backend
      * Return an array of all Themes available
      * @return array|false
      */
-	public function getThemes()
+	public function getAllThemes()
 	{
 		$objThemes = $this->Database->execute('SELECT id,name FROM tl_theme ORDER BY name');
 		if(!$objThemes->numRows)

--- a/dca/tl_user.php
+++ b/dca/tl_user.php
@@ -143,7 +143,7 @@ class tl_user_easy_themes extends Backend
 	public function getThemeModules(DataContainer $dc)
 	{
 		// if we don't have any themes at all this is going to be as empty as void
-		$arrThemes = $this->EasyThemes->getThemes();
+		$arrThemes = $this->EasyThemes->getAllThemes();
 		if(!$arrThemes)
 		{
 			return array();


### PR DESCRIPTION
This micro patch makes EasyThemes compatible with Contao devel again.

Current version raises:
`Fatal error: Cannot make static method Contao\Backend::getThemes() non static in class EasyThemes in /system/modules/easy_themes/EasyThemes.php on line 391`
