### PR TITLE
Fix loading of assets.

### DIFF
--- a/EasyThemes.php
+++ b/EasyThemes.php
@@ -30,32 +30,11 @@ class EasyThemes extends Backend
         // we never need to do anything at all if the user has no access to the themes module
         if (!BackendUser::getInstance()->hasAccess('themes', 'modules') || Input::get('popup')) {
             $this->blnLoadET = false;
-        }
-    }
-
-
-    /**
-     * Add CSS and Javascript
-     * @param string
-     * @return boolean
-     */
-    public function addHeadings($strName, $strLanguage)
-    {
-        if (!$this->blnLoadET) {
-            return false;
-        }
-
-        if (BackendUser::getInstance()->et_enable == 1) {
+        } elseif (BackendUser::getInstance()->et_enable == 1) {
             $GLOBALS['TL_CSS'][] = 'system/modules/easy_themes/html/easy_themes.css|screen';
             $GLOBALS['TL_JAVASCRIPT'][] = 'system/modules/easy_themes/html/easy_themes.js';
         }
-
-        // make sure the hook is only executed once
-        unset($GLOBALS['TL_HOOKS']['loadLanguageFile']['EasyThemesHook']);
-
-        return false;
     }
-
 
     /**
      * Add the container

--- a/config/config.php
+++ b/config/config.php
@@ -75,7 +75,6 @@ $GLOBALS['TL_EASY_THEMES_MODULES'] = array_merge
 if (!(($_GET['do'] == 'repository_manager' && $_GET['uninstall'] == 'easy_themes') || (strpos($_SERVER['PHP_SELF'], 'contao/install.php') !== false))) {
     if (TL_MODE == 'BE') {
         $GLOBALS['TL_HOOKS']['parseBackendTemplate'][] = array('EasyThemes', 'addContainer');
-        $GLOBALS['TL_HOOKS']['loadLanguageFile']['EasyThemesHook'] = array('EasyThemes', 'addHeadings');
         $GLOBALS['TL_HOOKS']['getUserNavigation'][] = array('EasyThemes', 'modifyUserNavigation');
         $GLOBALS['TL_HOOKS']['loadDataContainer'][] = array('EasyThemes', 'setUser');
     }


### PR DESCRIPTION
There are some cases there the easy themes assets are not properly injected. This is caused by the "loadLanguageFile" hack. If a language file is loaded before the user got authenticated then the assets loading would fail.

A language file can be loaded before authenticated when a model find method is triggered before (e.g. in a initializeSystem hook). See Https://github.com/contao/core/commit/fa81a2cdde6a96100ab008b128d55f20a164027e.

I don't see any reasons to use the `loadLanguageFile` hack at all. Adding it to the constructor work as well (it's triggered by the `loadDataContainer` hook first).