### PR TITLE
Remove usage of tl script

### DIFF
--- a/EasyThemes.php
+++ b/EasyThemes.php
@@ -164,6 +164,7 @@ class EasyThemes extends Backend
 
         System::loadLanguageFile('tl_theme');
         $arrReturn = array();
+        $url = System::getContainer()->get('router')->generate('contao_backend');
 
         foreach ($arrActiveModules as $strConfig) {
             $arrConfig = explode('::', $strConfig, 2);
@@ -173,7 +174,7 @@ class EasyThemes extends Backend
             // get the theme title
             $objTitle = Database::getInstance()->prepare('SELECT name,easy_themes_internalTitle FROM tl_theme WHERE id=?')->execute($intThemeId);
             $arrReturn[$intThemeId]['label'] = $objTitle->easy_themes_internalTitle ?: $objTitle->name;
-            $arrReturn[$intThemeId]['href'] = '/contao' . '?do=themes&amp;act=edit&amp;id=' . $intThemeId . '&rt=' . REQUEST_TOKEN;
+            $arrReturn[$intThemeId]['href'] = $url . '?do=themes&amp;act=edit&amp;id=' . $intThemeId . '&rt=' . REQUEST_TOKEN;
 
             // Decode ampersands for Contao 4.5 (see #39)
             if (version_compare(VERSION, '4.5', '>=')) {
@@ -220,7 +221,7 @@ class EasyThemes extends Backend
             if (isset($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href'])) {
                 $href = sprintf($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href'], $intThemeId);
             } else if (isset($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href_fragment'])) {
-                $href = '/contao' . '?do=themes&amp;' . $GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href_fragment'] . '&amp;id=' . $intThemeId;
+                $href = $url . '?do=themes&amp;' . $GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href_fragment'] . '&amp;id=' . $intThemeId;
             } else {
                 $href = 'javascript:alert(\'No href_fragment or href is specified for this module!\');';
             }

--- a/EasyThemes.php
+++ b/EasyThemes.php
@@ -164,7 +164,7 @@ class EasyThemes extends Backend
 
         System::loadLanguageFile('tl_theme');
         $arrReturn = array();
-        $url = System::getContainer()->get('router')->generate('contao_backend');
+        $router = System::getContainer()->get('router');
 
         foreach ($arrActiveModules as $strConfig) {
             $arrConfig = explode('::', $strConfig, 2);
@@ -174,12 +174,7 @@ class EasyThemes extends Backend
             // get the theme title
             $objTitle = Database::getInstance()->prepare('SELECT name,easy_themes_internalTitle FROM tl_theme WHERE id=?')->execute($intThemeId);
             $arrReturn[$intThemeId]['label'] = $objTitle->easy_themes_internalTitle ?: $objTitle->name;
-            $arrReturn[$intThemeId]['href'] = $url . '?do=themes&amp;act=edit&amp;id=' . $intThemeId . '&rt=' . REQUEST_TOKEN;
-
-            // Decode ampersands for Contao 4.5 (see #39)
-            if (version_compare(VERSION, '4.5', '>=')) {
-                $arrReturn[$intThemeId]['href'] = ampersand($arrReturn[$intThemeId]['href'], false);
-            }
+            $arrReturn[$intThemeId]['href'] = $router->generate('contao_backend', ['do' => 'themes', 'act' => 'edit', 'id' =>  $intThemeId, 'rt' => REQUEST_TOKEN]);
 
             // Append the module only if condition matches
             if (isset($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['appendIf'])) {
@@ -221,14 +216,10 @@ class EasyThemes extends Backend
             if (isset($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href'])) {
                 $href = sprintf($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href'], $intThemeId);
             } else if (isset($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href_fragment'])) {
-                $href = $url . '?do=themes&amp;' . $GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href_fragment'] . '&amp;id=' . $intThemeId;
+                $arrHrefFragment = explode('=', $GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href_fragment']);
+                $href = $router->generate('contao_backend', ['do' => 'themes', $arrHrefFragment[0] => $arrHrefFragment[1], 'id' =>  $intThemeId]);
             } else {
                 $href = 'javascript:alert(\'No href_fragment or href is specified for this module!\');';
-            }
-
-            // Decode ampersands for Contao 4.5 (see #39)
-            if (version_compare(VERSION, '4.5', '>=')) {
-                $href = ampersand($href, false);
             }
 
             // $icon - takes the given icon from the TL_EASY_THEMES_MODULES array or by default uses the Image::getHtml() method

--- a/EasyThemes.php
+++ b/EasyThemes.php
@@ -173,7 +173,7 @@ class EasyThemes extends Backend
             // get the theme title
             $objTitle = Database::getInstance()->prepare('SELECT name,easy_themes_internalTitle FROM tl_theme WHERE id=?')->execute($intThemeId);
             $arrReturn[$intThemeId]['label'] = $objTitle->easy_themes_internalTitle ?: $objTitle->name;
-            $arrReturn[$intThemeId]['href'] = TL_SCRIPT . '?do=themes&amp;act=edit&amp;id=' . $intThemeId . '&rt=' . REQUEST_TOKEN;
+            $arrReturn[$intThemeId]['href'] = '/contao' . '?do=themes&amp;act=edit&amp;id=' . $intThemeId . '&rt=' . REQUEST_TOKEN;
 
             // Decode ampersands for Contao 4.5 (see #39)
             if (version_compare(VERSION, '4.5', '>=')) {
@@ -220,7 +220,7 @@ class EasyThemes extends Backend
             if (isset($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href'])) {
                 $href = sprintf($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href'], $intThemeId);
             } else if (isset($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href_fragment'])) {
-                $href = TL_SCRIPT . '?do=themes&amp;' . $GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href_fragment'] . '&amp;id=' . $intThemeId;
+                $href = '/contao' . '?do=themes&amp;' . $GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['href_fragment'] . '&amp;id=' . $intThemeId;
             } else {
                 $href = 'javascript:alert(\'No href_fragment or href is specified for this module!\');';
             }

--- a/EasyThemes.php
+++ b/EasyThemes.php
@@ -176,6 +176,11 @@ class EasyThemes extends Backend
             $arrReturn[$intThemeId]['label'] = $objTitle->easy_themes_internalTitle ?: $objTitle->name;
             $arrReturn[$intThemeId]['href'] = $router->generate('contao_backend', ['do' => 'themes', 'act' => 'edit', 'id' =>  $intThemeId, 'rt' => REQUEST_TOKEN]);
 
+            // Decode ampersands for Contao 4.5 (see #39)
+            if (version_compare(VERSION, '4.5', '>=')) {
+                $arrReturn[$intThemeId]['href'] = ampersand($arrReturn[$intThemeId]['href'], false);
+            }
+
             // Append the module only if condition matches
             if (isset($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['appendIf'])) {
                 if ($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['appendIf']($intThemeId) !== true) {
@@ -220,6 +225,11 @@ class EasyThemes extends Backend
                 $href = $router->generate('contao_backend', ['do' => 'themes', $arrHrefFragment[0] => $arrHrefFragment[1], 'id' =>  $intThemeId]);
             } else {
                 $href = 'javascript:alert(\'No href_fragment or href is specified for this module!\');';
+            }
+
+            // Decode ampersands for Contao 4.5 (see #39)
+            if (version_compare(VERSION, '4.5', '>=')) {
+                $href = ampersand($href, false);
             }
 
             // $icon - takes the given icon from the TL_EASY_THEMES_MODULES array or by default uses the Image::getHtml() method


### PR DESCRIPTION
I use this extension in Contao 4.9.3
I display modules in "Backend Module" mode.
When I created a custom back end route for my own Contao extension, the following problem occurred: Whenever I am on my custom back end route, the navigation links of contao-easy_themes are created incorrectly.
I have fixed this by letting the Symfony router generate the correct path based on the Contao back end route name.
The constant TL_SCRIPT that was used for this is declared as deprecated anyway.