### PR TITLE
Some tweaks for PHP8

### DIFF
--- a/EasyThemes.php
+++ b/EasyThemes.php
@@ -194,7 +194,11 @@ class EasyThemes extends Backend
             } else {
                 // Special label handling for Contao 4.8+ (see #42)
                 if (version_compare(VERSION, '4.8', '>=')) {
-                    $title = sprintf($GLOBALS['TL_LANG']['tl_theme'][$strModule], $intThemeId);
+                    // Check if it is still an array and adjust accordingld (see #50)
+                    $title = sprintf(is_array($GLOBALS['TL_LANG']['tl_theme'][$strModule])
+                        ? $GLOBALS['TL_LANG']['tl_theme'][$strModule][1]
+                        : $GLOBALS['TL_LANG']['tl_theme'][$strModule],
+                        $intThemeId);
                 } else {
                     $title = sprintf($GLOBALS['TL_LANG']['tl_theme'][$strModule][1], $intThemeId);
                 }

--- a/config/config.php
+++ b/config/config.php
@@ -75,9 +75,12 @@ if (version_compare(VERSION, '4.8', '>=')) {
 // fix uninstall exception - see #756
 // fix database error - see #822
 // fix install exception - see #4
-$repositoryManager = $_GET['do'] == 'repository_manager' && $_GET['update'] == 'database';
+// fix 'undefined array key "do"'
+$repositoryManager = (isset($_GET['do']) && $_GET['do'] == 'repository_manager')
+    && (isset($_GET['update']) && $_GET['update'] == 'database');
 $installTool = strpos($_SERVER['PHP_SELF'], 'contao/install.php') !== false;
-$composer = $_GET['do'] == 'composer' && $_GET['update'] == 'database';
+$composer = (isset($_GET['do']) && $_GET['do'] == 'composer')
+    && (isset($_GET['update']) && $_GET['update'] == 'database');
 $beMode = TL_MODE == 'BE';
 
 if ($beMode


### PR DESCRIPTION
This PR adds a check inside the label handling in `EasyThemes.php` to prevent issue #50 as well as check in front of the $_GET access in `config/config.php` to prevent the "undefined array key" warning in PHP8