### PR TITLE
Fixing undefined array key warning

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -171,7 +171,7 @@ class Helper
             }
 
             // request token
-            if ($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['appendRT']) {
+            if ($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule]['appendRT'] ?? false) {
                 $href .= (false !== strpos($href, '?') ? '&' : '?').'rt='.REQUEST_TOKEN;
             }
 
@@ -225,7 +225,7 @@ class Helper
                 unset($params[$k]);
             }
 
-            if ('tl_theme' === $params['table']) {
+            if (isset($params['table']) && 'tl_theme' === $params['table']) {
                 unset($params['table']);
             }
         }


### PR DESCRIPTION
I have noticed some issues with `Undefined array key` while using this nice module.
While there might be some more places, that have to get changed, at least this will also fix #54 