### PR TITLE
Fix compatibility with contao 4.9

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -115,7 +115,7 @@ class Helper
                 'do' => 'themes',
                 'act' => 'edit',
                 'id' => $intThemeId,
-                'rt' => System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue(),
+                'rt' => function_exists(System::getDefaultTokenValue()) ? System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue()->getDefaultTokenValue() : REQUEST_TOKEN,
             ]);
 
             $arrReturn[$intThemeId]['href'] = StringUtil::ampersand($arrReturn[$intThemeId]['href'], false);

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -115,7 +115,7 @@ class Helper
                 'do' => 'themes',
                 'act' => 'edit',
                 'id' => $intThemeId,
-                'rt' => function_exists('\Contao\CoreBundle\Csrf\getDefaultTokenValue()') ? System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue()->getDefaultTokenValue() : REQUEST_TOKEN,
+                'rt' => System::getContainer()->get('contao.csrf.token_manager')->getToken(System::getContainer()->getParameter('contao.csrf_token_name'))->getValue(),
             ]);
 
             $arrReturn[$intThemeId]['href'] = StringUtil::ampersand($arrReturn[$intThemeId]['href'], false);

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -115,7 +115,7 @@ class Helper
                 'do' => 'themes',
                 'act' => 'edit',
                 'id' => $intThemeId,
-                'rt' => function_exists(System::getDefaultTokenValue()) ? System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue()->getDefaultTokenValue() : REQUEST_TOKEN,
+                'rt' => function_exists('\Contao\CoreBundle\Csrf\getDefaultTokenValue()') ? System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue()->getDefaultTokenValue() : REQUEST_TOKEN,
             ]);
 
             $arrReturn[$intThemeId]['href'] = StringUtil::ampersand($arrReturn[$intThemeId]['href'], false);


### PR DESCRIPTION
This pull request fixes the compatibility with contao version 4.9 caused by the use of the function 'getDefaultTokenValue()' which is only available in contao versions more recent than version 4.9.