### PR TITLE
Add check if module exist

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -105,6 +105,11 @@ class Helper
             $intThemeId = (int) $arrConfig[0];
             $strModule = $arrConfig[1];
 
+            // check if module is existing
+            if (!isset($GLOBALS['TL_EASY_THEMES_MODULES'][$strModule])) {
+                continue;
+            }
+
             // get the theme title
             $arrTheme = $this->connection->fetchAssociative(
                 'SELECT name, easy_themes_internalTitle FROM tl_theme WHERE id=?',


### PR DESCRIPTION
This PR add a simple check if a selected module is still existing.

I just stumbled over this issue as I removed a extension with easy_themes support and got a warning in the backend in dev mode.