### PR TITLE
Fix compatiblity with missing ArrayUtil in contao 4.9

### DIFF
--- a/src/EventListener/UserNavigationListener.php
+++ b/src/EventListener/UserNavigationListener.php
@@ -74,7 +74,11 @@ class UserNavigationListener
         if ($parentNavigation = $this->easyThemes->getParentNavigation()) {
             $intPosition = array_search($parentNavigation, array_keys($arrModules), true);
             ++$intPosition;
-            ArrayUtil::arrayInsert($arrModules, $intPosition, $arrThemeNavigation);
+            if (class_exists(ArrayUtil::class)) {
+                ArrayUtil::arrayInsert($arrModules, $intPosition, $arrThemeNavigation);
+            } else {
+                array_insert($arrModules, $intPosition, $arrThemeNavigation);
+            }
 
             return $arrModules;
         }


### PR DESCRIPTION
Unfortunately there is another incompatibility with contao 4.9 because of missing `ArrayUtil` 😢 

If you want to have a fixed version with #64, you can install our merged branch `hotfix/4.9` with the following in your `composer.json`. But attention we will remove that branch as soon as the hotfixed version is released!

```json
  "require": [
    {
      "terminal42/contao-easy_themes": "dev-hotfix/4.9 as 3.1.2-dev"
    },

  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/eikona-media/contao-easy_themes"
    },
```

P.S. After merging the hotfix - we should increase the dependencies to contao 4.13+!

